### PR TITLE
Fix stuck controls after restart

### DIFF
--- a/game.js
+++ b/game.js
@@ -23,6 +23,7 @@ class Game2048 extends Phaser.Scene {
   }
 
   create() {
+    this.isMoving = false;
     this.score = 0;
     this.highScore = parseInt(localStorage.getItem("highScore")) || 0;
     this.cameras.main.setBackgroundColor(this.theme.backgroundColor);


### PR DESCRIPTION
## Summary
- reset `isMoving` flag at the start of each scene to allow input after game restarts

## Testing
- `git status --short`
